### PR TITLE
Fix App test placeholder

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Add Todo input', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const inputElement = screen.getByPlaceholderText(/add todo here/i);
+  expect(inputElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- ensure the main test checks for the placeholder text that exists

## Testing
- `npm test -- -w 1 --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba0e5cb608329a438485ac21bab2e